### PR TITLE
⚡ Feat : Define common api response

### DIFF
--- a/src/main/java/slvtwn/khu/toyouserver/common/ApiResponse.java
+++ b/src/main/java/slvtwn/khu/toyouserver/common/ApiResponse.java
@@ -1,17 +1,23 @@
 package slvtwn.khu.toyouserver.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 
 @Getter
+@JsonPropertyOrder({"code", "message", "data", "pageInfo"})
 public class ApiResponse<T> {
 
 	private final String code;
 
 	private final String message;
 
+	@JsonInclude(Include.NON_NULL)
 	private final T data;
 
 	private final PageInfoResponse pageInfo;
+
 
 	ApiResponse(String code, String message) {
 		this.code = code;

--- a/src/main/java/slvtwn/khu/toyouserver/common/ApiResponse.java
+++ b/src/main/java/slvtwn/khu/toyouserver/common/ApiResponse.java
@@ -1,0 +1,53 @@
+package slvtwn.khu.toyouserver.common;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final String code;
+
+	private final String message;
+
+	private final T data;
+
+	private final Object pageInfo;
+
+	ApiResponse(String code, String message) {
+		this.code = code;
+		this.message = message;
+		this.data = null;
+		this.pageInfo = null;
+	}
+
+	ApiResponse(String code, String message, T data) {
+		this.code = code;
+		this.message = message;
+		this.data = data;
+		this.pageInfo = null;
+
+	}
+
+	ApiResponse(String code, String message, T data, Object pageInfo) {
+		this.code = code;
+		this.message = message;
+		this.data = data;
+		this.pageInfo = pageInfo;
+	}
+
+	public static <T> ApiResponse<T> success(SuccessType successType) {
+		return new ApiResponse<>(successType.getCode(), successType.getMessage());
+	}
+
+	public static <T> ApiResponse<T> success(SuccessType successType, T data) {
+		return new ApiResponse<>(successType.getCode(), successType.getMessage(), data);
+	}
+
+	public static <T> ApiResponse<T> success(SuccessType successType, T data, Object pageInfo) {
+		return new ApiResponse<>(successType.getCode(), successType.getMessage(), data, pageInfo);
+	}
+
+	public static <T> ApiResponse<T> error(ErrorType errorType) {
+		return new ApiResponse<>(errorType.getCode(), errorType.getMessage());
+	}
+}

--- a/src/main/java/slvtwn/khu/toyouserver/common/ApiResponse.java
+++ b/src/main/java/slvtwn/khu/toyouserver/common/ApiResponse.java
@@ -18,20 +18,12 @@ public class ApiResponse<T> {
 
 	private final PageInfoResponse pageInfo;
 
-
 	ApiResponse(String code, String message) {
-		this.code = code;
-		this.message = message;
-		this.data = null;
-		this.pageInfo = null;
+		this(code, message, null, null);
 	}
 
 	ApiResponse(String code, String message, T data) {
-		this.code = code;
-		this.message = message;
-		this.data = data;
-		this.pageInfo = null;
-
+		this(code, message, data, null);
 	}
 
 	ApiResponse(String code, String message, T data, PageInfoResponse pageInfo) {

--- a/src/main/java/slvtwn/khu/toyouserver/common/ApiResponse.java
+++ b/src/main/java/slvtwn/khu/toyouserver/common/ApiResponse.java
@@ -11,7 +11,7 @@ public class ApiResponse<T> {
 
 	private final T data;
 
-	private final Object pageInfo;
+	private final PageInfoResponse pageInfo;
 
 	ApiResponse(String code, String message) {
 		this.code = code;
@@ -28,7 +28,7 @@ public class ApiResponse<T> {
 
 	}
 
-	ApiResponse(String code, String message, T data, Object pageInfo) {
+	ApiResponse(String code, String message, T data, PageInfoResponse pageInfo) {
 		this.code = code;
 		this.message = message;
 		this.data = data;
@@ -43,11 +43,28 @@ public class ApiResponse<T> {
 		return new ApiResponse<>(successType.getCode(), successType.getMessage(), data);
 	}
 
-	public static <T> ApiResponse<T> success(SuccessType successType, T data, Object pageInfo) {
+	public static <T> ApiResponse<T> success(SuccessType successType, T data, PageInfoResponse pageInfo) {
 		return new ApiResponse<>(successType.getCode(), successType.getMessage(), data, pageInfo);
 	}
 
-	public static <T> ApiResponse<T> error(ErrorType errorType) {
+	public static ApiResponse<?> error(ErrorType errorType) {
 		return new ApiResponse<>(errorType.getCode(), errorType.getMessage());
 	}
+
+	public static <T> ApiResponse<T> error(ErrorType errorType, T data) {
+		return new ApiResponse<>(errorType.getCode(), errorType.getMessage(), data);
+	}
+
+	public static ApiResponse<?> error(ErrorType errorType, String message) {
+		return new ApiResponse<>(errorType.getCode(), message);
+	}
+
+	public static <T> ApiResponse<T> error(ErrorType errorType, String message, T data) {
+		return new ApiResponse<>(errorType.getCode(), message, data);
+	}
+
+	public static <T> ApiResponse<Exception> error(ErrorType errorType, Exception e) {
+		return new ApiResponse<>(errorType.getCode(), errorType.getMessage(), e);
+	}
+
 }

--- a/src/main/java/slvtwn/khu/toyouserver/common/ErrorType.java
+++ b/src/main/java/slvtwn/khu/toyouserver/common/ErrorType.java
@@ -1,0 +1,17 @@
+package slvtwn.khu.toyouserver.common;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ErrorType {
+
+	// 404 (Not Found)
+	NOT_FOUND("TYU404", "Not Found");
+
+	private final String code;
+
+	private final String message;
+}

--- a/src/main/java/slvtwn/khu/toyouserver/common/PageInfoResponse.java
+++ b/src/main/java/slvtwn/khu/toyouserver/common/PageInfoResponse.java
@@ -1,0 +1,19 @@
+package slvtwn.khu.toyouserver.common;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageInfoResponse {
+	private final int currentPage;
+
+	private final int totalPage;
+
+	private final int totalElements;
+
+	public static PageInfoResponse of(int currentPage, int totalPage, int totalElements) {
+		return new PageInfoResponse(currentPage, totalPage, totalElements);
+	}
+}

--- a/src/main/java/slvtwn/khu/toyouserver/common/SuccessType.java
+++ b/src/main/java/slvtwn/khu/toyouserver/common/SuccessType.java
@@ -1,0 +1,16 @@
+package slvtwn.khu.toyouserver.common;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SuccessType {
+
+	// 200 (OK)
+	OK("TYU200", "success");
+
+	private final String code;
+	private final String message;
+}


### PR DESCRIPTION
## 🚀 Related Issue

close: #6 

## 📌 Tasks

- 공통적으로 사용되는 API 응답 형식을 정의했습니다. 

## 📝 Details

- `PageInfoResponse`를 별도 분리해서 페이징 응답 관련 정보가 공통 응답의 하위 필드로 추가됩니다.
```java
@Getter
@JsonPropertyOrder({"code", "message", "data", "pageInfo"})
public class ApiResponse<T> {

	private final String code;

	private final String message;

	@JsonInclude(Include.NON_NULL)
	private final T data;

	private final PageInfoResponse pageInfo;
```

## 📚 Remarks

> Points or opinions to share teams

- Nullable response인 PageInfoResponse가 있어`Lombok` 으로 생성자 지정하지 않았는데 이에 따른 문제가 있다면 수정해야 합니다.
